### PR TITLE
Fix checkbox behaviour

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,7 +102,6 @@ textarea, .gr-text-input {
   background-color: var(--base);
 }
 
-.dark .gr-check-radio:focus,  .gr-check-radio:focus,
 .dark .gr-check-radio:checked, .gr-check-radio:checked {
   background-color: var(--accent);
 }


### PR DESCRIPTION
I've encountered a confusing checkbox behavior. When the checkbox is checked and then unchecked, it temporarily remains lit with the same color as when it was checked. Maybe you could return the checkbox to its original state (no color) when it is unchecked? Best regards👍

Checked (left), right after it's unchecked (right)
![image](https://user-images.githubusercontent.com/53343081/218139116-4cd8aced-ad8e-43db-8212-49d84352a971.png)