### PR TITLE
Fix text box arrows

### DIFF
--- a/style.css
+++ b/style.css
@@ -373,12 +373,9 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
-/* Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
+/* gradio 3.4.1 stuff for editable scrollbar values */
 .gr-box > div > div > input.gr-text-input {
-  width: 4em;
+  width: 6em;
 }
 
 .progressDiv .progress {


### PR DESCRIPTION
Remove Firefox section and change the width of gradio's text inputs to 6em, which is the default for this web-ui. These changes bring back the up and down arrows that can be clicked to change various values in the ui.