### PR TITLE
Matching "Interrupt" and "Skip" button colors to accent colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -209,12 +209,19 @@ margin-left: 10px;
 }
 
 #txt2img_interrupt, #img2img_interrupt {
-background-color: var(--red) !important;
-color: var(--mantle);
+  background-color: var(--accent) !important;
+  filter: hue-rotate(20deg);
+  color: var(--mantle);
+}
+
+#txt2img_interrupt:hover, #img2img_interrupt:hover {
+  background-color: var(--accent) !important;
+  filter: hue-rotate(20deg) brightness(130%);
+  color: var(--mantle);
 }
 
 #txt2img_skip, #img2img_skip {
-background-color: var(--maroon) !important;
+background-color: var(--accent) !important;
 color: var(--mantle);
 }
 

--- a/style.css
+++ b/style.css
@@ -28,7 +28,7 @@
   --mantle: #181825;
   --crust: #11111b;
   --shadow: #010409;
-  --accent: var(--maroon);
+  --accent: var(--sapphire);
   color-scheme: dark;
 }
 select, option {
@@ -209,15 +209,15 @@ margin-left: 10px;
 }
 
 #txt2img_interrupt, #img2img_interrupt {
-  background-color: var(--accent) !important;
-  filter: hue-rotate(20deg);
-  color: var(--mantle);
+background-color: var(--accent) !important;
+filter: hue-rotate(20deg);
+color: var(--mantle);
 }
 
 #txt2img_interrupt:hover, #img2img_interrupt:hover {
-  background-color: var(--accent) !important;
-  filter: hue-rotate(20deg) brightness(130%);
-  color: var(--mantle);
+background-color: var(--accent) !important;
+filter: hue-rotate(20deg) brightness(130%);
+color: var(--mantle);
 }
 
 #txt2img_skip, #img2img_skip {

--- a/style.css
+++ b/style.css
@@ -28,7 +28,7 @@
   --mantle: #181825;
   --crust: #11111b;
   --shadow: #010409;
-  --accent: var(--sapphire);
+  --accent: var(--maroon);
   color-scheme: dark;
 }
 select, option {


### PR DESCRIPTION
I noticed that the "Interrupt" and "Skip"buttons do not reflect the accent color of the theme.
The source seems to do so explicitly, but in my opinion, these buttons should also match the accent color.

This change will result in the following display. (accent color: sapphire)

![FpsEFXfaMAANggG](https://user-images.githubusercontent.com/43980268/221054996-b70bba85-73d4-4710-9f4e-9d78264fbd59.png)