### PR TITLE
Fix checkbox focus in legacy themes

### DIFF
--- a/flavors/legacy/frappe.css
+++ b/flavors/legacy/frappe.css
@@ -98,11 +98,11 @@ textarea, .gr-text-input {
   background-color: transparent;
   color: var(--text);
 }
+.dark .gr-check-radio:focus, .gr-check-radio:focus,
 .dark .gr-check-radio, .gr-check-radio {
   background-color: var(--base);
 }
 
-.dark .gr-check-radio:focus,  .gr-check-radio:focus,
 .dark .gr-check-radio:checked, .gr-check-radio:checked {
   background-color: var(--accent);
 }

--- a/flavors/legacy/latte.css
+++ b/flavors/legacy/latte.css
@@ -98,11 +98,11 @@ textarea, .gr-text-input {
   background-color: transparent;
   color: var(--text);
 }
+.dark .gr-check-radio:focus, .gr-check-radio:focus,
 .dark .gr-check-radio, .gr-check-radio {
   background-color: var(--base);
 }
 
-.dark .gr-check-radio:focus,  .gr-check-radio:focus,
 .dark .gr-check-radio:checked, .gr-check-radio:checked {
   background-color: var(--accent);
 }

--- a/flavors/legacy/macchiato.css
+++ b/flavors/legacy/macchiato.css
@@ -98,11 +98,11 @@ textarea, .gr-text-input {
   background-color: transparent;
   color: var(--text);
 }
+.dark .gr-check-radio:focus, .gr-check-radio:focus,
 .dark .gr-check-radio, .gr-check-radio {
   background-color: var(--base);
 }
 
-.dark .gr-check-radio:focus,  .gr-check-radio:focus,
 .dark .gr-check-radio:checked, .gr-check-radio:checked {
   background-color: var(--accent);
 }

--- a/flavors/legacy/mocha.css
+++ b/flavors/legacy/mocha.css
@@ -100,11 +100,11 @@ textarea, .gr-text-input {
   background-color: transparent;
   color: var(--text);
 }
+.dark .gr-check-radio:focus, .gr-check-radio:focus,
 .dark .gr-check-radio, .gr-check-radio {
   background-color: var(--base);
 }
 
-.dark .gr-check-radio:focus,  .gr-check-radio:focus,
 .dark .gr-check-radio:checked, .gr-check-radio:checked {
   background-color: var(--accent);
 }


### PR DESCRIPTION
Unticking checkboxes still displays the accent color in the legacy themes until the element loses focus, this fixes it.