### PR TITLE
restore spin arrow for numfields

### DIFF
--- a/flavors/frappe.css
+++ b/flavors/frappe.css
@@ -151,17 +151,6 @@ input[type='range']:focus::-ms-fill-upper {
   background: var(--ctp-overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/latte.css
+++ b/flavors/latte.css
@@ -151,17 +151,6 @@ input[type='range']:focus::-ms-fill-upper {
   background: var(--ctp-overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/legacy/frappe.css
+++ b/flavors/legacy/frappe.css
@@ -367,17 +367,6 @@ input[type="range"]:focus::-ms-fill-upper {
   background: var(--overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/legacy/latte.css
+++ b/flavors/legacy/latte.css
@@ -367,17 +367,6 @@ input[type="range"]:focus::-ms-fill-upper {
   background: var(--overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/legacy/macchiato.css
+++ b/flavors/legacy/macchiato.css
@@ -367,17 +367,6 @@ input[type="range"]:focus::-ms-fill-upper {
   background: var(--overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/legacy/mocha.css
+++ b/flavors/legacy/mocha.css
@@ -369,17 +369,6 @@ input[type="range"]:focus::-ms-fill-upper {
   background: var(--overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type="number"] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/macchiato.css
+++ b/flavors/macchiato.css
@@ -151,17 +151,6 @@ input[type='range']:focus::-ms-fill-upper {
   background: var(--ctp-overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/flavors/mocha.css
+++ b/flavors/mocha.css
@@ -151,17 +151,6 @@ input[type='range']:focus::-ms-fill-upper {
   background: var(--ctp-overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }

--- a/style.css
+++ b/style.css
@@ -151,17 +151,6 @@ input[type='range']:focus::-ms-fill-upper {
   background: var(--ctp-overlay0);
 }
 
-/* Chrome, Safari, Edge, Opera */
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-input[type='number'] {
-  -moz-appearance: textfield;
-}
 .gr-box > div > div > input.gr-text-input {
   width: 4em;
 }


### PR DESCRIPTION
Restores spin arrows for number fields, see #6 for the issue. I only tested on webkit, probably someone needs to check Firefox.

![image](https://github.com/catppuccin/stable-diffusion-webui/assets/19820721/d631d785-2957-447c-8ee4-ba287b169845)
